### PR TITLE
Simple Smoke Test

### DIFF
--- a/src/ServiceControl.TransportAdapter.sln
+++ b/src/ServiceControl.TransportAdapter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 15.0.26430.12
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceControl.TransportAdapter", "ServiceControl.TransportAdapter\ServiceControl.TransportAdapter.csproj", "{9B891C3B-8051-4BB5-9257-6A954CF908C3}"
 EndProject
@@ -14,6 +14,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SmokeTesting", "SmokeTesting", "{4847B670-5AD7-41D2-B278-47BA14466FF5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleEndpoint", "SmokeTesting\SampleEndpoint\SampleEndpoint.csproj", "{00927C6B-9A58-454B-8DB5-1A69F4242E5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleTransportAdapter", "SmokeTesting\SampleTransportAdapter\SampleTransportAdapter.csproj", "{804245B3-FC20-4EA3-94BA-ED4146A220E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,9 +39,21 @@ Global
 		{A7C5D568-75C5-4438-84E3-C0DDD10415FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7C5D568-75C5-4438-84E3-C0DDD10415FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7C5D568-75C5-4438-84E3-C0DDD10415FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00927C6B-9A58-454B-8DB5-1A69F4242E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00927C6B-9A58-454B-8DB5-1A69F4242E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00927C6B-9A58-454B-8DB5-1A69F4242E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00927C6B-9A58-454B-8DB5-1A69F4242E5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{804245B3-FC20-4EA3-94BA-ED4146A220E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{804245B3-FC20-4EA3-94BA-ED4146A220E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{804245B3-FC20-4EA3-94BA-ED4146A220E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{804245B3-FC20-4EA3-94BA-ED4146A220E2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{00927C6B-9A58-454B-8DB5-1A69F4242E5A} = {4847B670-5AD7-41D2-B278-47BA14466FF5}
+		{804245B3-FC20-4EA3-94BA-ED4146A220E2} = {4847B670-5AD7-41D2-B278-47BA14466FF5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C4B34858-23B4-46E6-9047-25DF40637C35}

--- a/src/SmokeTesting/SampleEndpoint/Program.cs
+++ b/src/SmokeTesting/SampleEndpoint/Program.cs
@@ -40,9 +40,7 @@ class SomeMessage
 
 class SomeMessageHandler : IHandleMessages<SomeMessage>
 {
-#pragma warning disable PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
     public Task Handle(SomeMessage message, IMessageHandlerContext context)
-#pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
     {
         Console.WriteLine($"Received {message.CustomerId} - ReplyTo: {context.MessageHeaders[Headers.ReplyToAddress]}");
         return new Random().Next(1000) % 2 == 1 ? throw new Exception("BAM!") : Task.CompletedTask;

--- a/src/SmokeTesting/SampleEndpoint/Program.cs
+++ b/src/SmokeTesting/SampleEndpoint/Program.cs
@@ -45,7 +45,6 @@ class SomeMessageHandler : IHandleMessages<SomeMessage>
 #pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
     {
         Console.WriteLine($"Received {message.CustomerId} - ReplyTo: {context.MessageHeaders[Headers.ReplyToAddress]}");
-        //throw new Exception("BAM!");
-        return Task.CompletedTask;
+        return new Random().Next(1000) % 2 == 1 ? throw new Exception("BAM!") : Task.CompletedTask;
     }
 }

--- a/src/SmokeTesting/SampleEndpoint/Program.cs
+++ b/src/SmokeTesting/SampleEndpoint/Program.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Sample Endpoint";
+
+        var config = new EndpointConfiguration("SampleEndpoint");
+        var transport = config.UseTransport<SqlServerTransport>();
+        transport.ConnectionString(@"Server=.\SQLEXPRESS;Database=NServiceBus;Integrated Security=SSPI;Max Pool Size=100");
+
+        config.UsePersistence<InMemoryPersistence>();
+        config.EnableInstallers();
+
+        config.AuditProcessedMessagesTo("audit");
+        config.Recoverability()
+            .Delayed(delayed => delayed.NumberOfRetries(0))
+            .Immediate(immediate => immediate.NumberOfRetries(0));
+
+        var endpoint = await Endpoint.Start(config)
+            .ConfigureAwait(false);
+
+        while (Console.ReadKey(true).Key != ConsoleKey.Escape)
+        {
+            await endpoint.SendLocal(new SomeMessage { CustomerId = Guid.NewGuid() })
+                .ConfigureAwait(false);
+        }
+
+        await endpoint.Stop().ConfigureAwait(false);
+    }
+}
+
+class SomeMessage
+{
+    public Guid CustomerId { get; set; }
+}
+
+class SomeMessageHandler : IHandleMessages<SomeMessage>
+{
+#pragma warning disable PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+    public Task Handle(SomeMessage message, IMessageHandlerContext context)
+#pragma warning restore PS0018 // A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+    {
+        Console.WriteLine($"Received {message.CustomerId} - ReplyTo: {context.MessageHeaders[Headers.ReplyToAddress]}");
+        //throw new Exception("BAM!");
+        return Task.CompletedTask;
+    }
+}

--- a/src/SmokeTesting/SampleEndpoint/SampleEndpoint.csproj
+++ b/src/SmokeTesting/SampleEndpoint/SampleEndpoint.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.4.6" />
+    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/SmokeTesting/SampleTransportAdapter/Program.cs
+++ b/src/SmokeTesting/SampleTransportAdapter/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using ServiceControl.TransportAdapter;
+
+class Program
+{
+    static async Task Main()
+    {
+        Console.Title = "Transport Adapter";
+
+        var config = new TransportAdapterConfig<SqlServerTransport, MsmqTransport>("Adapter");
+
+        config.CustomizeEndpointTransport(endpoints =>
+        {
+            endpoints.ConnectionString(
+                @"Server=.\SQLEXPRESS;Database=NServiceBus;Integrated Security=SSPI;Max Pool Size=100");
+        });
+
+        var adapter = TransportAdapter.Create(config);
+
+        await adapter.Start().ConfigureAwait(false);
+
+        while (Console.ReadKey(true).Key != ConsoleKey.Escape)
+        {
+        }
+
+        await adapter.Stop().ConfigureAwait(false);
+    }
+}
+

--- a/src/SmokeTesting/SampleTransportAdapter/SampleTransportAdapter.csproj
+++ b/src/SmokeTesting/SampleTransportAdapter/SampleTransportAdapter.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Transport.SqlServer" Version="6.2.0" />
+    <PackageReference Include="NServiceBus.Transport.Msmq" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ServiceControl.TransportAdapter\ServiceControl.TransportAdapter.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Requires:

1. A `.\SQLEXPRESS` Sql Server instance with an `NServiceBus` database
2. An MSMQ ServiceControl instance

Creates an endpoint running on the SQL transport that sends messages to itself. The handler can be modified to throw an exception and send the message to the error queue. This will get picked up by the transport adapter and forwarded to the ServiceControl instance via MSMQ. When the ServiceControl instance is used to retry the message, it should get routed all the way back to the endpoint running on SQL.