### PR TITLE
remove redundant condition in custom build props

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Remove after upgrading to NServiceBus 8.x -->
-    <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">0.9.0</ParticularAnalyzersVersion>
+    <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I made a small copypasta mistake in https://github.com/Particular/ServiceControl.TransportAdapter/pull/132